### PR TITLE
New sassModules option

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -105,7 +105,9 @@ function transform(file, env, callback) {
               return (0, _minimatch2.default)(filename, ignorePath);
             })) {
               // remove parent base path
-              imports.push('@import "' + (0, _slash2.default)(filename) + '"' + (isSass ? '' : ';'));
+              var prefix = options.sassModules ? '@use': '@import',
+                suffix = options.sassModules ? ' as *': ''; 
+              imports.push(prefix+' "' + (0, _slash2.default)(filename) + '"' + suffix + (isSass ? '' : ';'));
             }
           }
         });

--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,9 @@ function transform (file, env, callback, options = {}) {
             return minimatch(filename, ignorePath);
           })) {
             // remove parent base path
-            imports.push('@import "' + slash(filename) + '"' + (isSass ? '' : ';'));
+            var prefix = options.sassModules ? '@use': '@import',
+              suffix = options.sassModules ? ' as *': ''; 
+            imports.push(prefix+' "' + (0, _slash2.default)(filename) + '"' + suffix + (isSass ? '' : ';'));
           }
         }
       });


### PR DESCRIPTION
Add the sassModules option for the new @use syntax.

When using:
`sassGlob({sassModules: true})`

The following:
`@import 'folder/**/*.scss';`

will be converted to:
`
@use 'folder/style-1.scss' as *;
@use 'folder/style-2.scss' as *;
@use 'folder/style-3.scss' as *;
`